### PR TITLE
fix: binary cross entropy

### DIFF
--- a/slides/aml-06-linear-models-classification/index.html
+++ b/slides/aml-06-linear-models-classification/index.html
@@ -141,7 +141,7 @@ $$\log\left(\frac{p(y=1|x)}{p(y=-1|x)}\right) = w^T\textbf{x} + b$$
 
 $$p(y=1|\textbf{x}) = \frac{1}{1+e^{-w^T\textbf{x} -b }}$$
 
-`$$\min_{w \in ℝ^{p}, b \in \mathbb{R}} -\sum_{i=1}^n \log(\exp(-y_i(w^T \textbf{x}_i + b)) + 1)$$`
+`$$\min_{w \in ℝ^{p}, b \in \mathbb{R}} \sum_{i=1}^n \log(\exp(-y_i(w^T \textbf{x}_i + b)) + 1)$$`
 
 
 $$\hat{y} = \text{sign}(w^T\textbf{x} + b)$$
@@ -191,9 +191,9 @@ care about finding a simple solution.
 
 # Penalized Logistic Regression
 
-`$$\min_{w \in ℝ^{p}, b \in \mathbb{R}}-C \sum_{i=1}^n\log(\exp(-y_i(w^T \textbf{x}_i + b )) + 1) + ||w||_2^2$$`
+`$$\min_{w \in ℝ^{p}, b \in \mathbb{R}}C \sum_{i=1}^n\log(\exp(-y_i(w^T \textbf{x}_i + b )) + 1) + ||w||_2^2$$`
 
-`$$\min_{w \in ℝ^{p}, b \in \mathbb{R}}-C \sum_{i=1}^n\log(\exp(-y_i (w^T \textbf{x}_i + b)) + 1) + ||w||_1$$`
+`$$\min_{w \in ℝ^{p}, b \in \mathbb{R}}C \sum_{i=1}^n\log(\exp(-y_i (w^T \textbf{x}_i + b)) + 1) + ||w||_1$$`
 
 - C is inverse to alpha (or alpha / n_samples)
 
@@ -382,7 +382,7 @@ FIXME graph of not influencing the solution?
 class: center
 # Logistic Regression vs SVM
 .compact[
-`$$\min_{w \in ℝ^{p}, b \in \mathbb{R}}-C \sum_{i=1}^n\log(\exp(-y_i(w^T \textbf{x}_i+b)) + 1) + ||w||_2^2$$`
+`$$\min_{w \in ℝ^{p}, b \in \mathbb{R}}C \sum_{i=1}^n\log(\exp(-y_i(w^T \textbf{x}_i+b)) + 1) + ||w||_2^2$$`
 `$$\min_{w \in ℝ^{p}, b \in \mathbb{R}}C \sum_{i=1}^n\max(0,1-y_i(w^T \textbf{x}_i + b)) + ||w||_2^2$$`
 
 ![:scale 35%](images/binary_loss.png)


### PR DESCRIPTION
Without going into a derivation, one simple way to verifying that there is no negative is: `-log(exp(z)+1))` is not convex.

`log(exp(x)+1)` is convex and the sum of convex functions are convex.