### PR TITLE
Fix index

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -1,7 +1,7 @@
 
 <html>
 <body>
-<h2>https://amueller.github.io/COMS4995-s19/slides/</h2>
+<h2>https://amueller.github.io/COMS4995-s20/slides/</h2>
 <p>
     <li><a href="aml-01-introduction">aml-01-introduction</a></li>
     <li><a href="aml-02-matplotlib">aml-02-matplotlib</a></li>
@@ -10,23 +10,20 @@
     <li><a href="aml-05-linear-models-regression">aml-05-linear-models-regression</a></li>
     <li><a href="aml-06-linear-models-classification">aml-06-linear-models-classification</a></li>
     <li><a href="aml-07-trees-forests">aml-07-trees-forests</a></li>
-    <li><a href="aml-08-gradient-boosting-calibration">aml-08-gradient-boosting-calibration</a></li>
-    <li><a href="aml-10-model-evaluation">aml-10-model-evaluation</a></li>
-    <li><a href="aml-11-resampling-imbalanced-data">aml-11-resampling-imbalanced-data</a></li>
-    <li><a href="aml-12-interpretation-feature-selection">aml-12-interpretation-feature-selection</a></li>
-    <li><a href="aml-13-parameter-tuning-automl">aml-13-parameter-tuning-automl</a></li>
-    <li><a href="aml-14-dimensionality-reduction">aml-14-dimensionality-reduction</a></li>
-    <li><a href="aml-15-clustering-and-mixture-models">aml-15-clustering-and-mixture-models</a></li>
-    <li><a href="aml-16-nmf-outlier-detection">aml-16-nmf-outlier-detection</a></li>
-    <li><a href="aml-17-text-data">aml-17-text-data</a></li>
-    <li><a href="aml-18-topic-models">aml-18-topic-models</a></li>
-    <li><a href="aml-19-word-embeddings">aml-19-word-embeddings</a></li>
-    <li><a href="aml-20-neural-networks">aml-20-neural-networks</a></li>
-    <li><a href="aml-21-convolutional-nets">aml-21-convolutional-nets</a></li>
-    <li><a href="aml-22-advanced-nets">aml-22-advanced-nets</a></li>
-    <li><a href="aml-23-time-series">aml-23-time-series</a></li>
-    <li><a href="aml-24-recap">aml-24-recap</a></li>
-    <li><a href="aml-25-recommender-systems">aml-25-recommender-systems</a></li>
+    <li><a href="aml-08-gradient-boosting">aml-08-gradient-boosting</a></li>
+    <li><a href="aml-09-model-evaluation">aml-09-model-evaluation</a></li>
+    <li><a href="aml-10-calibration-imbalanced-data">aml-10-calibration-imbalanced-data</a></li>
+    <li><a href="aml-11-interpretation-feature-selection">aml-11-interpretation-feature-selection</a></li>
+    <li><a href="aml-12-parameter-tuning-automl">aml-12-parameter-tuning-automl</a></li>
+    <li><a href="aml-13-dimensionality-reduction">aml-13-dimensionality-reduction</a></li>
+    <li><a href="aml-14-clustering-mixture-models">aml-14-clustering-mixture-models</a></li>
+    <li><a href="aml-15-text-data">aml-15-text-data</a></li>
+    <li><a href="aml-16-topic-models">aml-16-topic-models</a></li>
+    <li><a href="aml-17-word-embeddings">aml-17-word-embeddings</a></li>
+    <li><a href="aml-18-neural-networks">aml-18-neural-networks</a></li>
+    <li><a href="aml-19-convolutional-nets">aml-19-convolutional-nets</a></li>
+    <li><a href="aml-20-advanced-nets">aml-20-advanced-nets</a></li>
+    <li><a href="aml-21-time-series">aml-21-time-series</a></li>
 </p>
 </body>
 </html>

--- a/slides/make_index.py
+++ b/slides/make_index.py
@@ -27,7 +27,7 @@ def main():
     directory = os.getcwd()
     fnames = glob.glob("aml-*")
     fnames.sort()
-    header = "https://amueller.github.io/COMS4995-s19/slides/"
+    header = "https://amueller.github.io/COMS4995-s20/slides/"
     with open("index.html", "w") as f:
         f.write(Template(INDEX_TEMPLATE).render(names=fnames, header=header))
 


### PR DESCRIPTION
The folder have changed since 2019 course repo so some of the links in https://amueller.github.io/COMS4995-s20/slides/ are broken, e.g. 
`aml-08-gradient-boosting-calibration` points to
https://amueller.github.io/COMS4995-s20/slides/aml-08-gradient-boosting-calibration. 

I updated `make_index.py` to use the right year and reran it.

